### PR TITLE
Skip credentials validations in custom AWS provider when creating the Kubernetes Cluster

### DIFF
--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/kubernetes/cluster.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/kubernetes/cluster.ts
@@ -385,6 +385,8 @@ export class Cluster extends pulumi.ComponentResource {
     return new aws.Provider(
       `${this.name}-provisioner`,
       {
+        // https://github.com/pulumi/pulumi-aws/issues/2144
+        skipCredentialsValidation: true,
         assumeRole: {
           roleArn: this.provisionerRole.arn.apply(async (arn) => {
             // Wait 30 seconds to assume the IAM Role


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fix #16 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```