### PR TITLE
Add awsServiceAccessPrincipals, enabledPolicyTypes and featureSet options to Organization

### DIFF
--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/landingzone/organization.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/landingzone/organization.ts
@@ -159,9 +159,9 @@ export class Organization extends pulumi.ComponentResource {
     const organization = new aws.organizations.Organization(
       this.name,
       {
-        awsServiceAccessPrincipals: ["cloudtrail.amazonaws.com"],
-        enabledPolicyTypes: ["SERVICE_CONTROL_POLICY"],
-        featureSet: "ALL",
+        awsServiceAccessPrincipals: this.args.awsServiceAccessPrincipals,
+        enabledPolicyTypes: this.args.enabledPolicyTypes,
+        featureSet: this.args.featureSet,
       },
       pulumi.mergeOptions(opts, {
         import: this.args.organizationId,

--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/landingzone/organizationArgs.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/landingzone/organizationArgs.ts
@@ -1,4 +1,5 @@
 import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
 import { AccountIamArgs } from "./accountIamArgs";
 
 export interface OrganizationArgs {
@@ -16,6 +17,21 @@ export interface OrganizationArgs {
    * The list of AWS Account to be configured in the Organization.
    */
   accounts?: OrganizationAccountArgs[];
+
+  /**
+   * The list of AWS Service Access Principals enabled in the organization.
+   */
+  awsServiceAccessPrincipals?: pulumi.Input<string>[];
+
+  /**
+   * The list of enabled Organizations Policies in the organization.
+   */
+  enabledPolicyTypes?: pulumi.Input<string>[];
+
+  /**
+   * The FeatureSet in the Organization..
+   */
+  featureSet?: pulumi.Input<string>;
 }
 
 export interface OrganizationPoliciesArgs {
@@ -113,6 +129,9 @@ export const defaultOrganizationArgs = {
   allowedRegions: [],
   policies: defaultPolicies,
   accounts: [],
+  awsServiceAccessPrincipals: ["cloudtrail.amazonaws.com"],
+  enabledPolicyTypes: ["SERVICE_CONTROL_POLICY"],
+  featureSet: "ALL",
 };
 
 export interface OrganizationalUnitMapping {

--- a/schema.yaml
+++ b/schema.yaml
@@ -466,6 +466,22 @@ types:
         items:
           description: The list of AWS Account to be configured in the Organization.
           $ref: "#/types/cloud-toolkit-aws:landingzone:OrganizationAccountArgs"
+      awsServiceAccessPrincipals:
+        description: The list of AWS Service Access Principals enabled in the organization.
+        type: array
+        items:
+          description: The list of AWS Service Access Principals enabled in the
+            organization.
+          type: string
+      enabledPolicyTypes:
+        description: The list of enabled Organizations Policies in the organization.
+        type: array
+        items:
+          description: The list of enabled Organizations Policies in the organization.
+          type: string
+      featureSet:
+        description: The FeatureSet in the Organization..
+        type: string
     type: object
   cloud-toolkit-aws:landingzone:OrganizationPoliciesArgs:
     properties:
@@ -1318,6 +1334,22 @@ resources:
         items:
           description: The list of AWS Account to be configured in the Organization.
           $ref: "#/types/cloud-toolkit-aws:landingzone:OrganizationAccountArgs"
+      awsServiceAccessPrincipals:
+        description: The list of AWS Service Access Principals enabled in the organization.
+        type: array
+        items:
+          description: The list of AWS Service Access Principals enabled in the
+            organization.
+          type: string
+      enabledPolicyTypes:
+        description: The list of enabled Organizations Policies in the organization.
+        type: array
+        items:
+          description: The list of enabled Organizations Policies in the organization.
+          type: string
+      featureSet:
+        description: The FeatureSet in the Organization..
+        type: string
     requiredInputs: []
     isComponent: true
     type: object

--- a/sdk/nodejs/landingzone/organization.ts
+++ b/sdk/nodejs/landingzone/organization.ts
@@ -68,6 +68,9 @@ export class Organization extends pulumi.ComponentResource {
         opts = opts || {};
         if (!opts.id) {
             resourceInputs["accounts"] = args ? args.accounts : undefined;
+            resourceInputs["awsServiceAccessPrincipals"] = args ? args.awsServiceAccessPrincipals : undefined;
+            resourceInputs["enabledPolicyTypes"] = args ? args.enabledPolicyTypes : undefined;
+            resourceInputs["featureSet"] = args ? args.featureSet : undefined;
             resourceInputs["organizationId"] = args ? args.organizationId : undefined;
             resourceInputs["policies"] = args ? args.policies : undefined;
             resourceInputs["accountIds"] = undefined /*out*/;
@@ -97,6 +100,18 @@ export interface OrganizationArgs {
      * The list of AWS Account to be configured in the Organization.
      */
     accounts?: pulumi.Input<pulumi.Input<inputs.landingzone.OrganizationAccountArgsArgs>[]>;
+    /**
+     * The list of AWS Service Access Principals enabled in the organization.
+     */
+    awsServiceAccessPrincipals?: pulumi.Input<pulumi.Input<string>[]>;
+    /**
+     * The list of enabled Organizations Policies in the organization.
+     */
+    enabledPolicyTypes?: pulumi.Input<pulumi.Input<string>[]>;
+    /**
+     * The FeatureSet in the Organization..
+     */
+    featureSet?: pulumi.Input<string>;
     /**
      * The organization ID to import the Organization in the stack. If not set a new AWS Organization will be created. Defaults to undefined.
      */

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -239,6 +239,18 @@ export namespace landingzone {
          */
         accounts?: pulumi.Input<pulumi.Input<inputs.landingzone.OrganizationAccountArgsArgs>[]>;
         /**
+         * The list of AWS Service Access Principals enabled in the organization.
+         */
+        awsServiceAccessPrincipals?: pulumi.Input<pulumi.Input<string>[]>;
+        /**
+         * The list of enabled Organizations Policies in the organization.
+         */
+        enabledPolicyTypes?: pulumi.Input<pulumi.Input<string>[]>;
+        /**
+         * The FeatureSet in the Organization..
+         */
+        featureSet?: pulumi.Input<string>;
+        /**
          * The organization ID to import the Organization in the stack. If not set a new AWS Organization will be created. Defaults to undefined.
          */
         organizationId?: pulumi.Input<string>;

--- a/sdk/python/cloud_toolkit_aws/landingzone/_inputs.py
+++ b/sdk/python/cloud_toolkit_aws/landingzone/_inputs.py
@@ -517,15 +517,27 @@ class OrganizationAccountArgsArgs:
 class OrganizationArgsArgs:
     def __init__(__self__, *,
                  accounts: Optional[pulumi.Input[Sequence[pulumi.Input['OrganizationAccountArgsArgs']]]] = None,
+                 aws_service_access_principals: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 enabled_policy_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 feature_set: Optional[pulumi.Input[str]] = None,
                  organization_id: Optional[pulumi.Input[str]] = None,
                  policies: Optional[pulumi.Input['OrganizationPoliciesArgsArgs']] = None):
         """
         :param pulumi.Input[Sequence[pulumi.Input['OrganizationAccountArgsArgs']]] accounts: The list of AWS Account to be configured in the Organization.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] aws_service_access_principals: The list of AWS Service Access Principals enabled in the organization.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] enabled_policy_types: The list of enabled Organizations Policies in the organization.
+        :param pulumi.Input[str] feature_set: The FeatureSet in the Organization..
         :param pulumi.Input[str] organization_id: The organization ID to import the Organization in the stack. If not set a new AWS Organization will be created. Defaults to undefined.
         :param pulumi.Input['OrganizationPoliciesArgsArgs'] policies: The Organization policies to be applied.
         """
         if accounts is not None:
             pulumi.set(__self__, "accounts", accounts)
+        if aws_service_access_principals is not None:
+            pulumi.set(__self__, "aws_service_access_principals", aws_service_access_principals)
+        if enabled_policy_types is not None:
+            pulumi.set(__self__, "enabled_policy_types", enabled_policy_types)
+        if feature_set is not None:
+            pulumi.set(__self__, "feature_set", feature_set)
         if organization_id is not None:
             pulumi.set(__self__, "organization_id", organization_id)
         if policies is not None:
@@ -542,6 +554,42 @@ class OrganizationArgsArgs:
     @accounts.setter
     def accounts(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['OrganizationAccountArgsArgs']]]]):
         pulumi.set(self, "accounts", value)
+
+    @property
+    @pulumi.getter(name="awsServiceAccessPrincipals")
+    def aws_service_access_principals(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+        """
+        The list of AWS Service Access Principals enabled in the organization.
+        """
+        return pulumi.get(self, "aws_service_access_principals")
+
+    @aws_service_access_principals.setter
+    def aws_service_access_principals(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
+        pulumi.set(self, "aws_service_access_principals", value)
+
+    @property
+    @pulumi.getter(name="enabledPolicyTypes")
+    def enabled_policy_types(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+        """
+        The list of enabled Organizations Policies in the organization.
+        """
+        return pulumi.get(self, "enabled_policy_types")
+
+    @enabled_policy_types.setter
+    def enabled_policy_types(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
+        pulumi.set(self, "enabled_policy_types", value)
+
+    @property
+    @pulumi.getter(name="featureSet")
+    def feature_set(self) -> Optional[pulumi.Input[str]]:
+        """
+        The FeatureSet in the Organization..
+        """
+        return pulumi.get(self, "feature_set")
+
+    @feature_set.setter
+    def feature_set(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "feature_set", value)
 
     @property
     @pulumi.getter(name="organizationId")

--- a/sdk/python/cloud_toolkit_aws/landingzone/organization.py
+++ b/sdk/python/cloud_toolkit_aws/landingzone/organization.py
@@ -18,16 +18,28 @@ __all__ = ['OrganizationArgs', 'Organization']
 class OrganizationArgs:
     def __init__(__self__, *,
                  accounts: Optional[pulumi.Input[Sequence[pulumi.Input['OrganizationAccountArgsArgs']]]] = None,
+                 aws_service_access_principals: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 enabled_policy_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 feature_set: Optional[pulumi.Input[str]] = None,
                  organization_id: Optional[pulumi.Input[str]] = None,
                  policies: Optional[pulumi.Input['OrganizationPoliciesArgsArgs']] = None):
         """
         The set of arguments for constructing a Organization resource.
         :param pulumi.Input[Sequence[pulumi.Input['OrganizationAccountArgsArgs']]] accounts: The list of AWS Account to be configured in the Organization.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] aws_service_access_principals: The list of AWS Service Access Principals enabled in the organization.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] enabled_policy_types: The list of enabled Organizations Policies in the organization.
+        :param pulumi.Input[str] feature_set: The FeatureSet in the Organization..
         :param pulumi.Input[str] organization_id: The organization ID to import the Organization in the stack. If not set a new AWS Organization will be created. Defaults to undefined.
         :param pulumi.Input['OrganizationPoliciesArgsArgs'] policies: The Organization policies to be applied.
         """
         if accounts is not None:
             pulumi.set(__self__, "accounts", accounts)
+        if aws_service_access_principals is not None:
+            pulumi.set(__self__, "aws_service_access_principals", aws_service_access_principals)
+        if enabled_policy_types is not None:
+            pulumi.set(__self__, "enabled_policy_types", enabled_policy_types)
+        if feature_set is not None:
+            pulumi.set(__self__, "feature_set", feature_set)
         if organization_id is not None:
             pulumi.set(__self__, "organization_id", organization_id)
         if policies is not None:
@@ -44,6 +56,42 @@ class OrganizationArgs:
     @accounts.setter
     def accounts(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['OrganizationAccountArgsArgs']]]]):
         pulumi.set(self, "accounts", value)
+
+    @property
+    @pulumi.getter(name="awsServiceAccessPrincipals")
+    def aws_service_access_principals(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+        """
+        The list of AWS Service Access Principals enabled in the organization.
+        """
+        return pulumi.get(self, "aws_service_access_principals")
+
+    @aws_service_access_principals.setter
+    def aws_service_access_principals(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
+        pulumi.set(self, "aws_service_access_principals", value)
+
+    @property
+    @pulumi.getter(name="enabledPolicyTypes")
+    def enabled_policy_types(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+        """
+        The list of enabled Organizations Policies in the organization.
+        """
+        return pulumi.get(self, "enabled_policy_types")
+
+    @enabled_policy_types.setter
+    def enabled_policy_types(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
+        pulumi.set(self, "enabled_policy_types", value)
+
+    @property
+    @pulumi.getter(name="featureSet")
+    def feature_set(self) -> Optional[pulumi.Input[str]]:
+        """
+        The FeatureSet in the Organization..
+        """
+        return pulumi.get(self, "feature_set")
+
+    @feature_set.setter
+    def feature_set(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "feature_set", value)
 
     @property
     @pulumi.getter(name="organizationId")
@@ -76,6 +124,9 @@ class Organization(pulumi.ComponentResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  accounts: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['OrganizationAccountArgsArgs']]]]] = None,
+                 aws_service_access_principals: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 enabled_policy_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 feature_set: Optional[pulumi.Input[str]] = None,
                  organization_id: Optional[pulumi.Input[str]] = None,
                  policies: Optional[pulumi.Input[pulumi.InputType['OrganizationPoliciesArgsArgs']]] = None,
                  __props__=None):
@@ -85,6 +136,9 @@ class Organization(pulumi.ComponentResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['OrganizationAccountArgsArgs']]]] accounts: The list of AWS Account to be configured in the Organization.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] aws_service_access_principals: The list of AWS Service Access Principals enabled in the organization.
+        :param pulumi.Input[Sequence[pulumi.Input[str]]] enabled_policy_types: The list of enabled Organizations Policies in the organization.
+        :param pulumi.Input[str] feature_set: The FeatureSet in the Organization..
         :param pulumi.Input[str] organization_id: The organization ID to import the Organization in the stack. If not set a new AWS Organization will be created. Defaults to undefined.
         :param pulumi.Input[pulumi.InputType['OrganizationPoliciesArgsArgs']] policies: The Organization policies to be applied.
         """
@@ -113,6 +167,9 @@ class Organization(pulumi.ComponentResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  accounts: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['OrganizationAccountArgsArgs']]]]] = None,
+                 aws_service_access_principals: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 enabled_policy_types: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 feature_set: Optional[pulumi.Input[str]] = None,
                  organization_id: Optional[pulumi.Input[str]] = None,
                  policies: Optional[pulumi.Input[pulumi.InputType['OrganizationPoliciesArgsArgs']]] = None,
                  __props__=None):
@@ -127,6 +184,9 @@ class Organization(pulumi.ComponentResource):
             __props__ = OrganizationArgs.__new__(OrganizationArgs)
 
             __props__.__dict__["accounts"] = accounts
+            __props__.__dict__["aws_service_access_principals"] = aws_service_access_principals
+            __props__.__dict__["enabled_policy_types"] = enabled_policy_types
+            __props__.__dict__["feature_set"] = feature_set
             __props__.__dict__["organization_id"] = organization_id
             __props__.__dict__["policies"] = policies
             __props__.__dict__["account_ids"] = None


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

Users should be able to import organizations with customized awsServiceAccessPrincipals, enabledPolicyTypes and featureSet values.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Add awsServiceAccessPrincipals, enabledPolicyTypes and featureSet options to Organization
```