### PR TITLE
Make CloudWatch optional in AuditLogging with a dedicated configuration

### DIFF
--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/landingzone/__tests__/auditLogging.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/landingzone/__tests__/auditLogging.ts
@@ -3,6 +3,8 @@ import * as pulumi from "@pulumi/pulumi";
 import { defaultAuditLoggingArgs } from "../auditLoggingArgs";
 import minimalConfiguration from "./fixtures/auditLoggingMinimalConfiguration";
 import retentionDaysConfiguration from "./fixtures/auditLoggingRetentionDays";
+import cloudwatchConfiguration from "./fixtures/auditLoggingCloudWatch";
+import cloudwatchRetentionDaysConfiguration from "./fixtures/auditLoggingCloudWatchRetentionDays";
 
 function GetValue<T>(output: pulumi.Output<T>) {
   return new Promise<T>((resolve, reject) => {
@@ -34,14 +36,14 @@ describe("Minimal configuration", function () {
     component = await import("../auditLogging");
   });
 
-  test("It should create the AWS Cloudwatch resources", async function () {
+  test("It shouldn't create the AWS Cloudwatch resources", async function () {
     const instance = new component.AuditLogging("test", minimalConfiguration);
 
-    expect(instance.cloudWatchLogGroup).toBeDefined();
-    expect(instance.cloudWatchRole).toBeDefined();
-    expect(instance.cloudWatchPolicy).toBeDefined();
-    expect(instance.cloudWatchRolePolicyAttachment).toBeDefined();
-    expect(instance.cloudWatchDashboard).toBeDefined();
+    expect(instance.cloudWatchLogGroup).toBeUndefined();
+    expect(instance.cloudWatchRole).toBeUndefined();
+    expect(instance.cloudWatchPolicy).toBeUndefined();
+    expect(instance.cloudWatchRolePolicyAttachment).toBeUndefined();
+    expect(instance.cloudWatchDashboard).toBeUndefined();
   });
 
   test("It should create the AWS S3 resources", async function () {
@@ -58,14 +60,6 @@ describe("Minimal configuration", function () {
     const instance = new component.AuditLogging("test", minimalConfiguration);
 
     expect(instance.trail).toBeDefined();
-  });
-
-  test("It should set the appropiate retention days in Cloudwatch LogGroup", async function () {
-    const instance = new component.AuditLogging("test", minimalConfiguration);
-
-    expect(await GetValue(instance.cloudWatchLogGroup.retentionInDays)).toBe(
-      defaultAuditLoggingArgs.retentionDays
-    );
   });
 
   test("It should set the appropiate retention days in S3 Bucket", async function () {
@@ -88,14 +82,6 @@ describe("RetentionDays configuration", function () {
     component = await import("../auditLogging");
   });
 
-  test("It should set the appropiate retention days in Cloudwatch LogGroup", async function () {
-    const instance = new component.AuditLogging("test", retentionDaysConfiguration);
-
-    expect(await GetValue(instance.cloudWatchLogGroup.retentionInDays)).toBe(
-      retentionDaysConfiguration.retentionDays
-    );
-  });
-
   test("It should set the appropiate retention days in S3 Bucket", async function () {
     const instance = new component.AuditLogging("test", retentionDaysConfiguration);
 
@@ -108,5 +94,57 @@ describe("RetentionDays configuration", function () {
         retentionDaysConfiguration.retentionDays
       );
     }
+  });
+});
+
+describe("CloudWatch enabled with custom RetentionDays", function () {
+  let component: typeof import("../auditLogging");
+
+  beforeAll(async function () {
+    component = await import("../auditLogging");
+  });
+
+  test("It should create the AWS Cloudwatch resources", async function () {
+    const instance = new component.AuditLogging("test", cloudwatchRetentionDaysConfiguration);
+
+    expect(instance.cloudWatchLogGroup).toBeDefined();
+    expect(instance.cloudWatchRole).toBeDefined();
+    expect(instance.cloudWatchPolicy).toBeDefined();
+    expect(instance.cloudWatchRolePolicyAttachment).toBeDefined();
+    expect(instance.cloudWatchDashboard).toBeDefined();
+  });
+
+  test("It should set the appropiate retention days in Cloudwatch LogGroup", async function () {
+    const instance = new component.AuditLogging("test", cloudwatchRetentionDaysConfiguration);
+
+    expect(await GetValue(instance.cloudWatchLogGroup.retentionInDays)).toBe(
+      cloudwatchRetentionDaysConfiguration.cloudwatch?.retentionDays
+    );
+  });
+});
+
+describe("CloudWatch enabled", function () {
+  let component: typeof import("../auditLogging");
+
+  beforeAll(async function () {
+    component = await import("../auditLogging");
+  });
+
+  test("It should create the AWS Cloudwatch resources", async function () {
+    const instance = new component.AuditLogging("test", cloudwatchConfiguration);
+
+    expect(instance.cloudWatchLogGroup).toBeDefined();
+    expect(instance.cloudWatchRole).toBeDefined();
+    expect(instance.cloudWatchPolicy).toBeDefined();
+    expect(instance.cloudWatchRolePolicyAttachment).toBeDefined();
+    expect(instance.cloudWatchDashboard).toBeDefined();
+  });
+
+  test("It should set the appropiate retention days in Cloudwatch LogGroup", async function () {
+    const instance = new component.AuditLogging("test", cloudwatchConfiguration);
+
+    expect(await GetValue(instance.cloudWatchLogGroup?.retentionInDays)).toBe(
+      defaultAuditLoggingArgs.cloudwatch.retentionDays
+    );
   });
 });

--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/landingzone/__tests__/fixtures/auditLoggingCloudWatch.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/landingzone/__tests__/fixtures/auditLoggingCloudWatch.ts
@@ -1,0 +1,5 @@
+export default {
+  cloudwatch: {
+    enabled: true,
+  }
+}

--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/landingzone/__tests__/fixtures/auditLoggingCloudWatchRetentionDays.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/landingzone/__tests__/fixtures/auditLoggingCloudWatchRetentionDays.ts
@@ -1,0 +1,6 @@
+export default {
+  cloudwatch: {
+    enabled: true,
+    retentionDays: 10,
+  }
+}

--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/landingzone/auditLoggingArgs.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/landingzone/auditLoggingArgs.ts
@@ -16,8 +16,29 @@ export interface AuditLoggingArgs {
    * The AWS provider to used to create the Bucket.
    */
   bucketProvider?: aws.Provider;
+
+  /**
+   * Store the audit logs in CloudWatch to enable easy searching.
+   */
+  cloudwatch?: AuditLoggingCloudWatchArgs;
+}
+
+export interface AuditLoggingCloudWatchArgs {
+  /**
+   * Enable storing audit logs in CloudWatch. Defaults to 'false'.
+   */
+  enabled: boolean;
+
+  /**
+   * The data retention in days. Defaults to '1'.
+   */
+  retentionDays?: number;
 }
 
 export const defaultAuditLoggingArgs = {
   retentionDays: 7,
+  cloudwatch: {
+    enabled: false,
+    retentionDays: 1,
+  },
 };

--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/landingzone/landingZone.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/landingzone/landingZone.ts
@@ -1,6 +1,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
-import { LandingZoneArgs, landingZoneDefaultIamRoles } from "./landingZoneArgs";
+import defaultsDeep from "lodash.defaultsdeep";
+import { LandingZoneArgs, landingZoneDefaultArgs, landingZoneDefaultIamRoles } from "./landingZoneArgs";
 import { AccountIam } from "./accountIam";
 import { AuditLogging } from "./auditLogging";
 import { IamTrustingAccount } from "./iamTrustingAccount";
@@ -53,6 +54,7 @@ export class LandingZone extends pulumi.ComponentResource {
   }
 
   private validateArgs(args: LandingZoneArgs): LandingZoneArgs {
+    const a = defaultsDeep({ ...args }, landingZoneDefaultArgs);
     return args;
   }
 
@@ -69,7 +71,7 @@ export class LandingZone extends pulumi.ComponentResource {
     if (this.args.audit?.accountName !== undefined) {
       bucketProvider = this.getAccountProvider(this.args.audit.accountName); 
       if (bucketProvider === undefined) {
-        pulumi.log.warn(
+        pulumi.log.error(
           `Audit account "${this.args.audit.accountName}"" not found. Please set the property "audit.accountName" with the name of one of the organization accounts.`,
           this
         );
@@ -79,8 +81,8 @@ export class LandingZone extends pulumi.ComponentResource {
     const auditLogging = new AuditLogging(
       this.name,
       {
-        retentionDays: this.args.audit?.retentionDays,
         bucketProvider: bucketProvider,
+        ...this.args.audit,
       },
       opts
     );

--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/landingzone/landingZoneArgs.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/landingzone/landingZoneArgs.ts
@@ -1,4 +1,5 @@
 import { OrganizationArgs } from "./organizationArgs";
+import { AuditLoggingArgs } from "./auditLoggingArgs";
 
 export interface LandingZoneArgs {
   organization?: OrganizationArgs;
@@ -7,8 +8,36 @@ export interface LandingZoneArgs {
 }
 
 export interface LandingZoneAuditArgs {
+  /**
+   * Enable audit logging. Defaults to 'true'.
+   */
   enabled?: boolean;
+
+  /**
+   * Select the Organization account to be used to store the audit logs.
+   */
   accountName?: string;
+
+  /**
+   * The data retention in days. Defaults to '7'.
+   */
+  retentionDays?: number;
+
+  /**
+   * Store the audit logs in CloudWatch to enable easy searching.
+   */
+  cloudwatch?: LandingZoneAuditCloudWatchArgs;
+}
+
+export interface LandingZoneAuditCloudWatchArgs {
+  /**
+   * Enable storing audit logs in CloudWatch. Defaults to 'false'.
+   */
+  enabled: boolean;
+
+  /**
+   * The data retention in days. Defaults to '1'.
+   */
   retentionDays?: number;
 }
 
@@ -41,5 +70,9 @@ export const landingZoneDefaultArgs = {
   audit: {
     enabled: false,
     retentionDays: 7,
+    cloudwatch: {
+      enabled: false,
+      retentionDays: 1,
+    }
   },
 };

--- a/schema.yaml
+++ b/schema.yaml
@@ -325,6 +325,18 @@ types:
       bucketProvider:
         description: The AWS provider to used to create the Bucket.
         $ref: /aws/v5.10.0/schema.json#/provider
+      cloudwatch:
+        description: Store the audit logs in CloudWatch to enable easy searching.
+        $ref: "#/types/cloud-toolkit-aws:landingzone:AuditLoggingCloudWatchArgs"
+    type: object
+  cloud-toolkit-aws:landingzone:AuditLoggingCloudWatchArgs:
+    properties:
+      enabled:
+        description: Enable storing audit logs in CloudWatch. Defaults to 'false'.
+        type: boolean
+      retentionDays:
+        description: The data retention in days. Defaults to '1'.
+        type: number
     type: object
   cloud-toolkit-aws:landingzone:IamTrustedAccountArgs:
     properties:
@@ -428,13 +440,25 @@ types:
   cloud-toolkit-aws:landingzone:LandingZoneAuditArgs:
     properties:
       enabled:
-        description: ""
+        description: Enable audit logging. Defaults to 'true'.
         type: boolean
       accountName:
-        description: ""
+        description: Select the Organization account to be used to store the audit logs.
         type: string
       retentionDays:
-        description: ""
+        description: The data retention in days. Defaults to '7'.
+        type: number
+      cloudwatch:
+        description: Store the audit logs in CloudWatch to enable easy searching.
+        $ref: "#/types/cloud-toolkit-aws:landingzone:LandingZoneAuditCloudWatchArgs"
+    type: object
+  cloud-toolkit-aws:landingzone:LandingZoneAuditCloudWatchArgs:
+    properties:
+      enabled:
+        description: Enable storing audit logs in CloudWatch. Defaults to 'false'.
+        type: boolean
+      retentionDays:
+        description: The data retention in days. Defaults to '1'.
         type: number
     type: object
   cloud-toolkit-aws:landingzone:LandingZoneIamArgs:
@@ -1154,11 +1178,6 @@ resources:
         description: The AWS Organization master account id.
         type: string
     required:
-      - cloudWatchLogGroup
-      - cloudWatchRole
-      - cloudWatchPolicy
-      - cloudWatchRolePolicyAttachment
-      - cloudWatchDashboard
       - bucket
       - bucketAcl
       - bucketPublicAccessBlock
@@ -1177,6 +1196,9 @@ resources:
       bucketProvider:
         description: The AWS provider to used to create the Bucket.
         $ref: /aws/v5.10.0/schema.json#/provider
+      cloudwatch:
+        description: Store the audit logs in CloudWatch to enable easy searching.
+        $ref: "#/types/cloud-toolkit-aws:landingzone:AuditLoggingCloudWatchArgs"
     requiredInputs: []
     isComponent: true
     type: object

--- a/sdk/nodejs/landingzone/auditLogging.ts
+++ b/sdk/nodejs/landingzone/auditLogging.ts
@@ -2,6 +2,9 @@
 // *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 import * as pulumi from "@pulumi/pulumi";
+import * as inputs from "../types/input";
+import * as outputs from "../types/output";
+import * as enums from "../types/enums";
 import * as utilities from "../utilities";
 
 import * as pulumiAws from "@pulumi/aws";
@@ -44,23 +47,23 @@ export class AuditLogging extends pulumi.ComponentResource {
     /**
      * The CloudWatch dashboard to review the audit logs.
      */
-    public /*out*/ readonly cloudWatchDashboard!: pulumi.Output<pulumiAws.cloudwatch.Dashboard>;
+    public /*out*/ readonly cloudWatchDashboard!: pulumi.Output<pulumiAws.cloudwatch.Dashboard | undefined>;
     /**
      * The CloudWatch Log Group used to store the data.
      */
-    public /*out*/ readonly cloudWatchLogGroup!: pulumi.Output<pulumiAws.cloudwatch.LogGroup>;
+    public /*out*/ readonly cloudWatchLogGroup!: pulumi.Output<pulumiAws.cloudwatch.LogGroup | undefined>;
     /**
      * The IAM Policy used by the IAM Role for Cloud Trail.
      */
-    public /*out*/ readonly cloudWatchPolicy!: pulumi.Output<pulumiAws.iam.Policy>;
+    public /*out*/ readonly cloudWatchPolicy!: pulumi.Output<pulumiAws.iam.Policy | undefined>;
     /**
      * The IAM Role used by Cloud Trail to write to CloudWatch..
      */
-    public /*out*/ readonly cloudWatchRole!: pulumi.Output<pulumiAws.iam.Role>;
+    public /*out*/ readonly cloudWatchRole!: pulumi.Output<pulumiAws.iam.Role | undefined>;
     /**
      * The IAM Role Policy Attachments that attach the IAM Role with the IAM Policy.
      */
-    public /*out*/ readonly cloudWatchRolePolicyAttachment!: pulumi.Output<pulumiAws.iam.RolePolicyAttachment>;
+    public /*out*/ readonly cloudWatchRolePolicyAttachment!: pulumi.Output<pulumiAws.iam.RolePolicyAttachment | undefined>;
     /**
      * The AWS Organization id.
      */
@@ -86,6 +89,7 @@ export class AuditLogging extends pulumi.ComponentResource {
         opts = opts || {};
         if (!opts.id) {
             resourceInputs["bucketProvider"] = args ? args.bucketProvider : undefined;
+            resourceInputs["cloudwatch"] = args ? args.cloudwatch : undefined;
             resourceInputs["region"] = args ? args.region : undefined;
             resourceInputs["retentionDays"] = args ? args.retentionDays : undefined;
             resourceInputs["bucket"] = undefined /*out*/;
@@ -129,6 +133,10 @@ export interface AuditLoggingArgs {
      * The AWS provider to used to create the Bucket.
      */
     bucketProvider?: pulumi.Input<pulumiAws.Provider>;
+    /**
+     * Store the audit logs in CloudWatch to enable easy searching.
+     */
+    cloudwatch?: pulumi.Input<inputs.landingzone.AuditLoggingCloudWatchArgsArgs>;
     /**
      * The region to be used to store the data.
      */

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -180,6 +180,17 @@ export namespace landingzone {
         requireUppercaseCharacters?: pulumi.Input<boolean>;
     }
 
+    export interface AuditLoggingCloudWatchArgsArgs {
+        /**
+         * Enable storing audit logs in CloudWatch. Defaults to 'false'.
+         */
+        enabled?: pulumi.Input<boolean>;
+        /**
+         * The data retention in days. Defaults to '1'.
+         */
+        retentionDays?: pulumi.Input<number>;
+    }
+
     export interface IamTrustedAccountRoleArgsArgs {
         name?: pulumi.Input<string>;
     }
@@ -190,8 +201,32 @@ export namespace landingzone {
     }
 
     export interface LandingZoneAuditArgsArgs {
+        /**
+         * Select the Organization account to be used to store the audit logs.
+         */
         accountName?: pulumi.Input<string>;
+        /**
+         * Store the audit logs in CloudWatch to enable easy searching.
+         */
+        cloudwatch?: pulumi.Input<inputs.landingzone.LandingZoneAuditCloudWatchArgsArgs>;
+        /**
+         * Enable audit logging. Defaults to 'true'.
+         */
         enabled?: pulumi.Input<boolean>;
+        /**
+         * The data retention in days. Defaults to '7'.
+         */
+        retentionDays?: pulumi.Input<number>;
+    }
+
+    export interface LandingZoneAuditCloudWatchArgsArgs {
+        /**
+         * Enable storing audit logs in CloudWatch. Defaults to 'false'.
+         */
+        enabled?: pulumi.Input<boolean>;
+        /**
+         * The data retention in days. Defaults to '1'.
+         */
         retentionDays?: pulumi.Input<number>;
     }
 

--- a/sdk/python/cloud_toolkit_aws/landingzone/_inputs.py
+++ b/sdk/python/cloud_toolkit_aws/landingzone/_inputs.py
@@ -13,9 +13,11 @@ __all__ = [
     'AccountIamArgsArgs',
     'AccountPasswordPolicyArgsArgs',
     'AccountPasswordPolicyRulesArgsArgs',
+    'AuditLoggingCloudWatchArgsArgs',
     'IamTrustedAccountRoleArgsArgs',
     'IamTrustingAccountRoleArgsArgs',
     'LandingZoneAuditArgsArgs',
+    'LandingZoneAuditCloudWatchArgsArgs',
     'LandingZoneIamArgsArgs',
     'LandingZoneIamRoleArgsArgs',
     'OrganizationAccountArgsArgs',
@@ -254,6 +256,45 @@ class AccountPasswordPolicyRulesArgsArgs:
 
 
 @pulumi.input_type
+class AuditLoggingCloudWatchArgsArgs:
+    def __init__(__self__, *,
+                 enabled: Optional[pulumi.Input[bool]] = None,
+                 retention_days: Optional[pulumi.Input[float]] = None):
+        """
+        :param pulumi.Input[bool] enabled: Enable storing audit logs in CloudWatch. Defaults to 'false'.
+        :param pulumi.Input[float] retention_days: The data retention in days. Defaults to '1'.
+        """
+        if enabled is not None:
+            pulumi.set(__self__, "enabled", enabled)
+        if retention_days is not None:
+            pulumi.set(__self__, "retention_days", retention_days)
+
+    @property
+    @pulumi.getter
+    def enabled(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Enable storing audit logs in CloudWatch. Defaults to 'false'.
+        """
+        return pulumi.get(self, "enabled")
+
+    @enabled.setter
+    def enabled(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "enabled", value)
+
+    @property
+    @pulumi.getter(name="retentionDays")
+    def retention_days(self) -> Optional[pulumi.Input[float]]:
+        """
+        The data retention in days. Defaults to '1'.
+        """
+        return pulumi.get(self, "retention_days")
+
+    @retention_days.setter
+    def retention_days(self, value: Optional[pulumi.Input[float]]):
+        pulumi.set(self, "retention_days", value)
+
+
+@pulumi.input_type
 class IamTrustedAccountRoleArgsArgs:
     def __init__(__self__, *,
                  name: Optional[pulumi.Input[str]] = None):
@@ -303,10 +344,19 @@ class IamTrustingAccountRoleArgsArgs:
 class LandingZoneAuditArgsArgs:
     def __init__(__self__, *,
                  account_name: Optional[pulumi.Input[str]] = None,
+                 cloudwatch: Optional[pulumi.Input['LandingZoneAuditCloudWatchArgsArgs']] = None,
                  enabled: Optional[pulumi.Input[bool]] = None,
                  retention_days: Optional[pulumi.Input[float]] = None):
+        """
+        :param pulumi.Input[str] account_name: Select the Organization account to be used to store the audit logs.
+        :param pulumi.Input['LandingZoneAuditCloudWatchArgsArgs'] cloudwatch: Store the audit logs in CloudWatch to enable easy searching.
+        :param pulumi.Input[bool] enabled: Enable audit logging. Defaults to 'true'.
+        :param pulumi.Input[float] retention_days: The data retention in days. Defaults to '7'.
+        """
         if account_name is not None:
             pulumi.set(__self__, "account_name", account_name)
+        if cloudwatch is not None:
+            pulumi.set(__self__, "cloudwatch", cloudwatch)
         if enabled is not None:
             pulumi.set(__self__, "enabled", enabled)
         if retention_days is not None:
@@ -315,6 +365,9 @@ class LandingZoneAuditArgsArgs:
     @property
     @pulumi.getter(name="accountName")
     def account_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Select the Organization account to be used to store the audit logs.
+        """
         return pulumi.get(self, "account_name")
 
     @account_name.setter
@@ -323,7 +376,22 @@ class LandingZoneAuditArgsArgs:
 
     @property
     @pulumi.getter
+    def cloudwatch(self) -> Optional[pulumi.Input['LandingZoneAuditCloudWatchArgsArgs']]:
+        """
+        Store the audit logs in CloudWatch to enable easy searching.
+        """
+        return pulumi.get(self, "cloudwatch")
+
+    @cloudwatch.setter
+    def cloudwatch(self, value: Optional[pulumi.Input['LandingZoneAuditCloudWatchArgsArgs']]):
+        pulumi.set(self, "cloudwatch", value)
+
+    @property
+    @pulumi.getter
     def enabled(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Enable audit logging. Defaults to 'true'.
+        """
         return pulumi.get(self, "enabled")
 
     @enabled.setter
@@ -333,6 +401,48 @@ class LandingZoneAuditArgsArgs:
     @property
     @pulumi.getter(name="retentionDays")
     def retention_days(self) -> Optional[pulumi.Input[float]]:
+        """
+        The data retention in days. Defaults to '7'.
+        """
+        return pulumi.get(self, "retention_days")
+
+    @retention_days.setter
+    def retention_days(self, value: Optional[pulumi.Input[float]]):
+        pulumi.set(self, "retention_days", value)
+
+
+@pulumi.input_type
+class LandingZoneAuditCloudWatchArgsArgs:
+    def __init__(__self__, *,
+                 enabled: Optional[pulumi.Input[bool]] = None,
+                 retention_days: Optional[pulumi.Input[float]] = None):
+        """
+        :param pulumi.Input[bool] enabled: Enable storing audit logs in CloudWatch. Defaults to 'false'.
+        :param pulumi.Input[float] retention_days: The data retention in days. Defaults to '1'.
+        """
+        if enabled is not None:
+            pulumi.set(__self__, "enabled", enabled)
+        if retention_days is not None:
+            pulumi.set(__self__, "retention_days", retention_days)
+
+    @property
+    @pulumi.getter
+    def enabled(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Enable storing audit logs in CloudWatch. Defaults to 'false'.
+        """
+        return pulumi.get(self, "enabled")
+
+    @enabled.setter
+    def enabled(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "enabled", value)
+
+    @property
+    @pulumi.getter(name="retentionDays")
+    def retention_days(self) -> Optional[pulumi.Input[float]]:
+        """
+        The data retention in days. Defaults to '1'.
+        """
         return pulumi.get(self, "retention_days")
 
     @retention_days.setter

--- a/sdk/python/cloud_toolkit_aws/landingzone/audit_logging.py
+++ b/sdk/python/cloud_toolkit_aws/landingzone/audit_logging.py
@@ -8,6 +8,7 @@ import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
 from .. import _utilities
+from ._inputs import *
 import pulumi_aws
 
 __all__ = ['AuditLoggingArgs', 'AuditLogging']
@@ -16,16 +17,20 @@ __all__ = ['AuditLoggingArgs', 'AuditLogging']
 class AuditLoggingArgs:
     def __init__(__self__, *,
                  bucket_provider: Optional[pulumi.Input['pulumi_aws.Provider']] = None,
+                 cloudwatch: Optional[pulumi.Input['AuditLoggingCloudWatchArgsArgs']] = None,
                  region: Optional[pulumi.Input[str]] = None,
                  retention_days: Optional[pulumi.Input[float]] = None):
         """
         The set of arguments for constructing a AuditLogging resource.
         :param pulumi.Input['pulumi_aws.Provider'] bucket_provider: The AWS provider to used to create the Bucket.
+        :param pulumi.Input['AuditLoggingCloudWatchArgsArgs'] cloudwatch: Store the audit logs in CloudWatch to enable easy searching.
         :param pulumi.Input[str] region: The region to be used to store the data.
         :param pulumi.Input[float] retention_days: The data retention in days. Defaults to '7'.
         """
         if bucket_provider is not None:
             pulumi.set(__self__, "bucket_provider", bucket_provider)
+        if cloudwatch is not None:
+            pulumi.set(__self__, "cloudwatch", cloudwatch)
         if region is not None:
             pulumi.set(__self__, "region", region)
         if retention_days is not None:
@@ -42,6 +47,18 @@ class AuditLoggingArgs:
     @bucket_provider.setter
     def bucket_provider(self, value: Optional[pulumi.Input['pulumi_aws.Provider']]):
         pulumi.set(self, "bucket_provider", value)
+
+    @property
+    @pulumi.getter
+    def cloudwatch(self) -> Optional[pulumi.Input['AuditLoggingCloudWatchArgsArgs']]:
+        """
+        Store the audit logs in CloudWatch to enable easy searching.
+        """
+        return pulumi.get(self, "cloudwatch")
+
+    @cloudwatch.setter
+    def cloudwatch(self, value: Optional[pulumi.Input['AuditLoggingCloudWatchArgsArgs']]):
+        pulumi.set(self, "cloudwatch", value)
 
     @property
     @pulumi.getter
@@ -74,6 +91,7 @@ class AuditLogging(pulumi.ComponentResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  bucket_provider: Optional[pulumi.Input['pulumi_aws.Provider']] = None,
+                 cloudwatch: Optional[pulumi.Input[pulumi.InputType['AuditLoggingCloudWatchArgsArgs']]] = None,
                  region: Optional[pulumi.Input[str]] = None,
                  retention_days: Optional[pulumi.Input[float]] = None,
                  __props__=None):
@@ -82,6 +100,7 @@ class AuditLogging(pulumi.ComponentResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input['pulumi_aws.Provider'] bucket_provider: The AWS provider to used to create the Bucket.
+        :param pulumi.Input[pulumi.InputType['AuditLoggingCloudWatchArgsArgs']] cloudwatch: Store the audit logs in CloudWatch to enable easy searching.
         :param pulumi.Input[str] region: The region to be used to store the data.
         :param pulumi.Input[float] retention_days: The data retention in days. Defaults to '7'.
         """
@@ -109,6 +128,7 @@ class AuditLogging(pulumi.ComponentResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  bucket_provider: Optional[pulumi.Input['pulumi_aws.Provider']] = None,
+                 cloudwatch: Optional[pulumi.Input[pulumi.InputType['AuditLoggingCloudWatchArgsArgs']]] = None,
                  region: Optional[pulumi.Input[str]] = None,
                  retention_days: Optional[pulumi.Input[float]] = None,
                  __props__=None):
@@ -123,6 +143,7 @@ class AuditLogging(pulumi.ComponentResource):
             __props__ = AuditLoggingArgs.__new__(AuditLoggingArgs)
 
             __props__.__dict__["bucket_provider"] = bucket_provider
+            __props__.__dict__["cloudwatch"] = cloudwatch
             __props__.__dict__["region"] = region
             __props__.__dict__["retention_days"] = retention_days
             __props__.__dict__["bucket"] = None
@@ -187,7 +208,7 @@ class AuditLogging(pulumi.ComponentResource):
 
     @property
     @pulumi.getter(name="cloudWatchDashboard")
-    def cloud_watch_dashboard(self) -> pulumi.Output['pulumi_aws.cloudwatch.Dashboard']:
+    def cloud_watch_dashboard(self) -> pulumi.Output[Optional['pulumi_aws.cloudwatch.Dashboard']]:
         """
         The CloudWatch dashboard to review the audit logs.
         """
@@ -195,7 +216,7 @@ class AuditLogging(pulumi.ComponentResource):
 
     @property
     @pulumi.getter(name="cloudWatchLogGroup")
-    def cloud_watch_log_group(self) -> pulumi.Output['pulumi_aws.cloudwatch.LogGroup']:
+    def cloud_watch_log_group(self) -> pulumi.Output[Optional['pulumi_aws.cloudwatch.LogGroup']]:
         """
         The CloudWatch Log Group used to store the data.
         """
@@ -203,7 +224,7 @@ class AuditLogging(pulumi.ComponentResource):
 
     @property
     @pulumi.getter(name="cloudWatchPolicy")
-    def cloud_watch_policy(self) -> pulumi.Output['pulumi_aws.iam.Policy']:
+    def cloud_watch_policy(self) -> pulumi.Output[Optional['pulumi_aws.iam.Policy']]:
         """
         The IAM Policy used by the IAM Role for Cloud Trail.
         """
@@ -211,7 +232,7 @@ class AuditLogging(pulumi.ComponentResource):
 
     @property
     @pulumi.getter(name="cloudWatchRole")
-    def cloud_watch_role(self) -> pulumi.Output['pulumi_aws.iam.Role']:
+    def cloud_watch_role(self) -> pulumi.Output[Optional['pulumi_aws.iam.Role']]:
         """
         The IAM Role used by Cloud Trail to write to CloudWatch..
         """
@@ -219,7 +240,7 @@ class AuditLogging(pulumi.ComponentResource):
 
     @property
     @pulumi.getter(name="cloudWatchRolePolicyAttachment")
-    def cloud_watch_role_policy_attachment(self) -> pulumi.Output['pulumi_aws.iam.RolePolicyAttachment']:
+    def cloud_watch_role_policy_attachment(self) -> pulumi.Output[Optional['pulumi_aws.iam.RolePolicyAttachment']]:
         """
         The IAM Role Policy Attachments that attach the IAM Role with the IAM Policy.
         """


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**

Make CloudWatch optional in AuditLogging with a dedicated configuration.

**Which issue(s) this PR fixes**

Fixes #24 #25 

**Special notes for your reviewer**

**Does this PR introduce a user-facing change?**
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Add option to enable CloudWatch in AuditLogging
Add option to customize data retention for CloudWatch in AuditLogging
```
