### PR TITLE
Fix CNI max number of pods

### DIFF
--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/kubernetes/cluster.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/kubernetes/cluster.ts
@@ -553,7 +553,9 @@ users:
         namespace: "kube-system",
         version: "1.1.21",
         values: {
-          ENABLE_PREFIX_DELEGATION: "true",
+          env: {
+            ENABLE_PREFIX_DELEGATION: "true",
+          }
         },
       },
       opts


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**
Fixes the issue of only allowing 17 pods per node by default in EKS. 

**Which issue(s) this PR fixes**
solves: https://github.com/cloud-toolkit/cloud-toolkit-aws/issues/74

**Does this PR introduce a user-facing change?**
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Fixes CNI issue that only allowed 17 pods to exist in each node.
```
