### PR TITLE
Manage ADOT LogGroups with Pulumi

### DIFF
--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/kubernetes/adotApplicationArgs.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/kubernetes/adotApplicationArgs.ts
@@ -8,11 +8,6 @@ import { IrsaApplicationAddonArgs } from "./applicationAddonArgs";
 
 export interface AdotApplicationLoggingItemArgs {
   /**
-   * Enable logging.
-   */
-  enabled: boolean;
-
-  /**
    * Data retention expressed in days.
    */
   dataRetention: number;
@@ -22,15 +17,20 @@ export interface AdotApplicationMetricsArgs {
   /**
    * Enable metrics.
    */
-  enabled: boolean;
+  enabled?: boolean;
 
   /**
    * Data retention expressed in days.
    */
-  dataRetention: number;
+  dataRetention?: number;
 }
 
 export interface AdotApplicationLoggingArgs {
+  /**
+   * Enable logging.
+   */
+  enabled: boolean;
+
   /**
    * Configure applications logging.
    */

--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/kubernetes/clusterAddonsArgs.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/kubernetes/clusterAddonsArgs.ts
@@ -89,16 +89,14 @@ export const defaultClusterAddonsArgs = {
     }
   },
   logging: {
+    enabled: true,
     applications: {
-      enabled: true,
       dataRetention: 1,
     },
     dataplane: {
-      enabled: false,
       dataRetention: 1,
     },
     host: {
-      enabled: false,
       dataRetention: 1,
     },
   },

--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/provider.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/provider.ts
@@ -375,10 +375,13 @@ async function constructKubernetesAdotApplication(
   return {
     urn: resource.urn,
     state: {
+      adotCollectorIRSA: resource.adotCollectorIRSA,
       application: resource.application,
-      CWLogGroup: resource.CWLogGroup,
-      adotCollectorIrsa: resource.adotCollectorIRSA,
-      fluentBitIrsa: resource.fluentBitIRSA,
+      fluentBitIRSA: resource.fluentBitIRSA,
+      logGroupApplicationLog: resource.logGroupApplicationLog,
+      logGroupDataplaneLog: resource.logGroupDataplaneLog,
+      logGroupHostLog: resource.logGroupHostLog,
+      logGroupMetrics: resource.logGroupMetrics,
       namespace: resource.namespace,
     },
   };

--- a/schema.yaml
+++ b/schema.yaml
@@ -267,15 +267,11 @@ types:
       - token
   cloud-toolkit-aws:kubernetes:AdotApplicationLoggingItemArgs:
     properties:
-      enabled:
-        description: Enable logging.
-        type: boolean
       dataRetention:
         description: Data retention expressed in days.
         type: number
     type: object
     required:
-      - enabled
       - dataRetention
   cloud-toolkit-aws:kubernetes:AdotApplicationMetricsArgs:
     properties:
@@ -286,11 +282,12 @@ types:
         description: Data retention expressed in days.
         type: number
     type: object
-    required:
-      - enabled
-      - dataRetention
+    required: []
   cloud-toolkit-aws:kubernetes:AdotApplicationLoggingArgs:
     properties:
+      enabled:
+        description: Enable logging.
+        type: boolean
       applications:
         description: Configure applications logging.
         $ref: "#/types/cloud-toolkit-aws:kubernetes:AdotApplicationLoggingItemArgs"
@@ -301,7 +298,8 @@ types:
         description: Configure host logging.
         $ref: "#/types/cloud-toolkit-aws:kubernetes:AdotApplicationLoggingItemArgs"
     type: object
-    required: []
+    required:
+      - enabled
   cloud-toolkit-aws:kubernetes:AdotApplicationArgs:
     properties:
       logging:
@@ -1626,7 +1624,16 @@ resources:
       namespace:
         description: ""
         $ref: /kubernetes/v3.21.2/schema.json#/resources/kubernetes:core/v1:Namespace
-      CWLogGroup:
+      logGroupApplicationLog:
+        description: ""
+        $ref: /aws/v5.10.0/schema.json#/resources/aws:cloudwatch%2flogGroup:LogGroup
+      logGroupDataplaneLog:
+        description: ""
+        $ref: /aws/v5.10.0/schema.json#/resources/aws:cloudwatch%2flogGroup:LogGroup
+      logGroupHostLog:
+        description: ""
+        $ref: /aws/v5.10.0/schema.json#/resources/aws:cloudwatch%2flogGroup:LogGroup
+      logGroupMetrics:
         description: ""
         $ref: /aws/v5.10.0/schema.json#/resources/aws:cloudwatch%2flogGroup:LogGroup
       fluentBitIRSA:
@@ -1639,9 +1646,6 @@ resources:
         description: ""
         $ref: /kubernetes/v3.21.2/schema.json#/resources/kubernetes:apiextensions.k8s.io:CustomResource
     required:
-      - CWLogGroup
-      - fluentBitIRSA
-      - adotCollectorIRSA
       - application
     inputProperties:
       logging:

--- a/sdk/nodejs/kubernetes/adotApplication.ts
+++ b/sdk/nodejs/kubernetes/adotApplication.ts
@@ -27,10 +27,13 @@ export class AdotApplication extends pulumi.ComponentResource {
         return obj['__pulumiType'] === AdotApplication.__pulumiType;
     }
 
-    public /*out*/ readonly CWLogGroup!: pulumi.Output<pulumiAws.cloudwatch.LogGroup>;
-    public /*out*/ readonly adotCollectorIRSA!: pulumi.Output<Irsa>;
+    public /*out*/ readonly adotCollectorIRSA!: pulumi.Output<Irsa | undefined>;
     public /*out*/ readonly application!: pulumi.Output<pulumiKubernetes.apiextensions.CustomResource>;
-    public /*out*/ readonly fluentBitIRSA!: pulumi.Output<Irsa>;
+    public /*out*/ readonly fluentBitIRSA!: pulumi.Output<Irsa | undefined>;
+    public /*out*/ readonly logGroupApplicationLog!: pulumi.Output<pulumiAws.cloudwatch.LogGroup | undefined>;
+    public /*out*/ readonly logGroupDataplaneLog!: pulumi.Output<pulumiAws.cloudwatch.LogGroup | undefined>;
+    public /*out*/ readonly logGroupHostLog!: pulumi.Output<pulumiAws.cloudwatch.LogGroup | undefined>;
+    public /*out*/ readonly logGroupMetrics!: pulumi.Output<pulumiAws.cloudwatch.LogGroup | undefined>;
     public /*out*/ readonly namespace!: pulumi.Output<pulumiKubernetes.core.v1.Namespace | undefined>;
 
     /**
@@ -54,16 +57,22 @@ export class AdotApplication extends pulumi.ComponentResource {
             resourceInputs["clusterName"] = args ? args.clusterName : undefined;
             resourceInputs["logging"] = args ? args.logging : undefined;
             resourceInputs["metrics"] = args ? args.metrics : undefined;
-            resourceInputs["CWLogGroup"] = undefined /*out*/;
             resourceInputs["adotCollectorIRSA"] = undefined /*out*/;
             resourceInputs["application"] = undefined /*out*/;
             resourceInputs["fluentBitIRSA"] = undefined /*out*/;
+            resourceInputs["logGroupApplicationLog"] = undefined /*out*/;
+            resourceInputs["logGroupDataplaneLog"] = undefined /*out*/;
+            resourceInputs["logGroupHostLog"] = undefined /*out*/;
+            resourceInputs["logGroupMetrics"] = undefined /*out*/;
             resourceInputs["namespace"] = undefined /*out*/;
         } else {
-            resourceInputs["CWLogGroup"] = undefined /*out*/;
             resourceInputs["adotCollectorIRSA"] = undefined /*out*/;
             resourceInputs["application"] = undefined /*out*/;
             resourceInputs["fluentBitIRSA"] = undefined /*out*/;
+            resourceInputs["logGroupApplicationLog"] = undefined /*out*/;
+            resourceInputs["logGroupDataplaneLog"] = undefined /*out*/;
+            resourceInputs["logGroupHostLog"] = undefined /*out*/;
+            resourceInputs["logGroupMetrics"] = undefined /*out*/;
             resourceInputs["namespace"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -128,6 +128,10 @@ export namespace kubernetes {
          */
         dataplane?: pulumi.Input<inputs.kubernetes.AdotApplicationLoggingItemArgsArgs>;
         /**
+         * Enable logging.
+         */
+        enabled: pulumi.Input<boolean>;
+        /**
          * Configure host logging.
          */
         host?: pulumi.Input<inputs.kubernetes.AdotApplicationLoggingItemArgsArgs>;
@@ -138,21 +142,17 @@ export namespace kubernetes {
          * Data retention expressed in days.
          */
         dataRetention: pulumi.Input<number>;
-        /**
-         * Enable logging.
-         */
-        enabled: pulumi.Input<boolean>;
     }
 
     export interface AdotApplicationMetricsArgsArgs {
         /**
          * Data retention expressed in days.
          */
-        dataRetention: pulumi.Input<number>;
+        dataRetention?: pulumi.Input<number>;
         /**
          * Enable metrics.
          */
-        enabled: pulumi.Input<boolean>;
+        enabled?: pulumi.Input<boolean>;
     }
 
     export interface ClusterAddonsIngressArgsArgs {

--- a/sdk/python/cloud_toolkit_aws/kubernetes/_inputs.py
+++ b/sdk/python/cloud_toolkit_aws/kubernetes/_inputs.py
@@ -52,20 +52,35 @@ class AddonsArgsArgs:
 @pulumi.input_type
 class AdotApplicationLoggingArgsArgs:
     def __init__(__self__, *,
+                 enabled: pulumi.Input[bool],
                  applications: Optional[pulumi.Input['AdotApplicationLoggingItemArgsArgs']] = None,
                  dataplane: Optional[pulumi.Input['AdotApplicationLoggingItemArgsArgs']] = None,
                  host: Optional[pulumi.Input['AdotApplicationLoggingItemArgsArgs']] = None):
         """
+        :param pulumi.Input[bool] enabled: Enable logging.
         :param pulumi.Input['AdotApplicationLoggingItemArgsArgs'] applications: Configure applications logging.
         :param pulumi.Input['AdotApplicationLoggingItemArgsArgs'] dataplane: Configure data plane logging.
         :param pulumi.Input['AdotApplicationLoggingItemArgsArgs'] host: Configure host logging.
         """
+        pulumi.set(__self__, "enabled", enabled)
         if applications is not None:
             pulumi.set(__self__, "applications", applications)
         if dataplane is not None:
             pulumi.set(__self__, "dataplane", dataplane)
         if host is not None:
             pulumi.set(__self__, "host", host)
+
+    @property
+    @pulumi.getter
+    def enabled(self) -> pulumi.Input[bool]:
+        """
+        Enable logging.
+        """
+        return pulumi.get(self, "enabled")
+
+    @enabled.setter
+    def enabled(self, value: pulumi.Input[bool]):
+        pulumi.set(self, "enabled", value)
 
     @property
     @pulumi.getter
@@ -107,14 +122,11 @@ class AdotApplicationLoggingArgsArgs:
 @pulumi.input_type
 class AdotApplicationLoggingItemArgsArgs:
     def __init__(__self__, *,
-                 data_retention: pulumi.Input[float],
-                 enabled: pulumi.Input[bool]):
+                 data_retention: pulumi.Input[float]):
         """
         :param pulumi.Input[float] data_retention: Data retention expressed in days.
-        :param pulumi.Input[bool] enabled: Enable logging.
         """
         pulumi.set(__self__, "data_retention", data_retention)
-        pulumi.set(__self__, "enabled", enabled)
 
     @property
     @pulumi.getter(name="dataRetention")
@@ -127,54 +139,44 @@ class AdotApplicationLoggingItemArgsArgs:
     @data_retention.setter
     def data_retention(self, value: pulumi.Input[float]):
         pulumi.set(self, "data_retention", value)
-
-    @property
-    @pulumi.getter
-    def enabled(self) -> pulumi.Input[bool]:
-        """
-        Enable logging.
-        """
-        return pulumi.get(self, "enabled")
-
-    @enabled.setter
-    def enabled(self, value: pulumi.Input[bool]):
-        pulumi.set(self, "enabled", value)
 
 
 @pulumi.input_type
 class AdotApplicationMetricsArgsArgs:
     def __init__(__self__, *,
-                 data_retention: pulumi.Input[float],
-                 enabled: pulumi.Input[bool]):
+                 data_retention: Optional[pulumi.Input[float]] = None,
+                 enabled: Optional[pulumi.Input[bool]] = None):
         """
         :param pulumi.Input[float] data_retention: Data retention expressed in days.
         :param pulumi.Input[bool] enabled: Enable metrics.
         """
-        pulumi.set(__self__, "data_retention", data_retention)
-        pulumi.set(__self__, "enabled", enabled)
+        if data_retention is not None:
+            pulumi.set(__self__, "data_retention", data_retention)
+        if enabled is not None:
+            pulumi.set(__self__, "enabled", enabled)
 
     @property
     @pulumi.getter(name="dataRetention")
-    def data_retention(self) -> pulumi.Input[float]:
+    def data_retention(self) -> Optional[pulumi.Input[float]]:
         """
         Data retention expressed in days.
         """
         return pulumi.get(self, "data_retention")
 
     @data_retention.setter
-    def data_retention(self, value: pulumi.Input[float]):
+    def data_retention(self, value: Optional[pulumi.Input[float]]):
         pulumi.set(self, "data_retention", value)
 
     @property
     @pulumi.getter
-    def enabled(self) -> pulumi.Input[bool]:
+    def enabled(self) -> Optional[pulumi.Input[bool]]:
         """
         Enable metrics.
         """
         return pulumi.get(self, "enabled")
 
     @enabled.setter
-    def enabled(self, value: pulumi.Input[bool]):
+    def enabled(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "enabled", value)
 
 

--- a/sdk/python/cloud_toolkit_aws/kubernetes/adot_application.py
+++ b/sdk/python/cloud_toolkit_aws/kubernetes/adot_application.py
@@ -149,10 +149,13 @@ class AdotApplication(pulumi.ComponentResource):
             __props__.__dict__["cluster_name"] = cluster_name
             __props__.__dict__["logging"] = logging
             __props__.__dict__["metrics"] = metrics
-            __props__.__dict__["cw_log_group"] = None
             __props__.__dict__["adot_collector_irsa"] = None
             __props__.__dict__["application"] = None
             __props__.__dict__["fluent_bit_irsa"] = None
+            __props__.__dict__["log_group_application_log"] = None
+            __props__.__dict__["log_group_dataplane_log"] = None
+            __props__.__dict__["log_group_host_log"] = None
+            __props__.__dict__["log_group_metrics"] = None
             __props__.__dict__["namespace"] = None
         super(AdotApplication, __self__).__init__(
             'cloud-toolkit-aws:kubernetes:AdotApplication',
@@ -162,13 +165,8 @@ class AdotApplication(pulumi.ComponentResource):
             remote=True)
 
     @property
-    @pulumi.getter(name="CWLogGroup")
-    def cw_log_group(self) -> pulumi.Output['pulumi_aws.cloudwatch.LogGroup']:
-        return pulumi.get(self, "cw_log_group")
-
-    @property
     @pulumi.getter(name="adotCollectorIRSA")
-    def adot_collector_irsa(self) -> pulumi.Output[Any]:
+    def adot_collector_irsa(self) -> pulumi.Output[Optional[Any]]:
         return pulumi.get(self, "adot_collector_irsa")
 
     @property
@@ -178,8 +176,28 @@ class AdotApplication(pulumi.ComponentResource):
 
     @property
     @pulumi.getter(name="fluentBitIRSA")
-    def fluent_bit_irsa(self) -> pulumi.Output[Any]:
+    def fluent_bit_irsa(self) -> pulumi.Output[Optional[Any]]:
         return pulumi.get(self, "fluent_bit_irsa")
+
+    @property
+    @pulumi.getter(name="logGroupApplicationLog")
+    def log_group_application_log(self) -> pulumi.Output[Optional['pulumi_aws.cloudwatch.LogGroup']]:
+        return pulumi.get(self, "log_group_application_log")
+
+    @property
+    @pulumi.getter(name="logGroupDataplaneLog")
+    def log_group_dataplane_log(self) -> pulumi.Output[Optional['pulumi_aws.cloudwatch.LogGroup']]:
+        return pulumi.get(self, "log_group_dataplane_log")
+
+    @property
+    @pulumi.getter(name="logGroupHostLog")
+    def log_group_host_log(self) -> pulumi.Output[Optional['pulumi_aws.cloudwatch.LogGroup']]:
+        return pulumi.get(self, "log_group_host_log")
+
+    @property
+    @pulumi.getter(name="logGroupMetrics")
+    def log_group_metrics(self) -> pulumi.Output[Optional['pulumi_aws.cloudwatch.LogGroup']]:
+        return pulumi.get(self, "log_group_metrics")
 
     @property
     @pulumi.getter


### PR DESCRIPTION
**What type of PR is this?**

/kind improvement

**What this PR does / why we need it**

Delete Log Groups in CloudWatch when the Kubernetes Cluster is deleted.
Avoid deploying adot-collector and fluentbit when not required.

**Which issue(s) this PR fixes**

Fixes #92 

**Special notes for your reviewer**

**Does this PR introduce a user-facing change?**
```release-note
NONE
```
