### PR TITLE
Accept an empty list of NodeGroups in Kubernetes Cluster

### DIFF
--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/kubernetes/__tests__/cluster.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/kubernetes/__tests__/cluster.ts
@@ -2,6 +2,7 @@ import * as pulumi from "@pulumi/pulumi";
 import minimalConfiguration from "./fixtures/cluster-minimal-configuration";
 import customNetworking from "./fixtures/cluster-custom-netwokring";
 import nodeGroupConfiguration from "./fixtures/cluster-node-group";
+import withoutNodeGroupConfiguration from "./fixtures/cluster-withoutNodeGroups";
 import customVpcConfiguration from "./fixtures/cluster-customVpc";
 import publicSubnetIdsConfiguration from "./fixtures/cluster-customPublicSubnetIds";
 import privateSubnetIdsConfiguration from "./fixtures/cluster-customPrivateSubnetIds";
@@ -156,6 +157,24 @@ describe("Minimal configuration", function () {
     expect(instance.defaultOidcProvider).toBeDefined();
   });
 });
+
+describe("Without Node Groups", function () {
+  let component: typeof import("../cluster");
+  let instance;
+
+  beforeAll(async function () {
+    component = await import("../cluster");
+  });
+
+  test("It shouldn't create any NodeGroups", async function () {
+    instance = new component.Cluster(
+      "without-node-group",
+      withoutNodeGroupConfiguration
+    );
+    expect(instance.nodeGroups.length).toBe(0);
+  });
+});
+
 
 describe("Custom Node Groups", function () {
   let component: typeof import("../cluster");

--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/kubernetes/__tests__/fixtures/cluster-withoutNodeGroups.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/kubernetes/__tests__/fixtures/cluster-withoutNodeGroups.ts
@@ -1,0 +1,6 @@
+export default {
+  nodeGroups: [],
+  addons: {
+    enabled: false
+  }
+};

--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/kubernetes/cluster.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/kubernetes/cluster.ts
@@ -12,6 +12,7 @@ import {
   defaultVersion,
   defaultClusterArgs,
   defaultNodeGroup,
+  defaultNodeGroups,
 } from "./clusterArgs";
 
 export { ClusterArgs, ClusterSubnetsType };
@@ -191,7 +192,9 @@ export class Cluster extends pulumi.ComponentResource {
   }
 
   private validateArgs(a: ClusterArgs): ClusterArgs {
-    const args = defaultsDeep({ ...a }, defaultClusterArgs);
+    const {nodeGroups,...cleanClusterArgs} = a;
+    const args = defaultsDeep({ ...cleanClusterArgs }, defaultClusterArgs);
+    args.nodeGroups = a.nodeGroups || defaultNodeGroups;
 
     for (const [index, nodeGroup] of args.nodeGroups.entries()) {
       args.nodeGroups[index] = defaultsDeep({ ...nodeGroup }, defaultNodeGroup);


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**

Create Kubernetes Cluster without any NodeGroup.

**Which issue(s) this PR fixes**

Fixes #94 

**Special notes for your reviewer**

**Does this PR introduce a user-facing change?**
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Accept an empy list of NodeGroups in Kubernetes Cluster
```
