### PR TITLE
Fix python templates

### DIFF
--- a/templates/email-sender-python/requirements.txt
+++ b/templates/email-sender-python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
--e /tmp/bin #cloud_toolkit_aws
+cloud-toolkit-aws>=0.5.2

--- a/templates/kubernetes-cluster-python/requirements.txt
+++ b/templates/kubernetes-cluster-python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
--e /tmp/bin #cloud_toolkit_aws
+cloud-toolkit-aws>=0.5.2

--- a/templates/serverless-queue-python/requirements.txt
+++ b/templates/serverless-queue-python/requirements.txt
@@ -1,2 +1,2 @@
 pulumi>=3.0.0,<4.0.0
--e /tmp/bin #cloud_toolkit_aws
+cloud-toolkit-aws>=0.5.2


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**

Python templates weren't using cloud_toolkit_aws as an external dependency


