### PR TITLE
Removed SDK workaround in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,6 @@ install_provider:: build_provider
 gen_nodejs_sdk::
 	rm -rf sdk/nodejs
 	cd provider/cmd/${CODEGEN} && go run . nodejs ../../../sdk/nodejs ${SCHEMA_PATH}
-	echo 'import "@pulumi/aws";' >> sdk/nodejs/index.ts
-	echo 'import "@pulumi/kubernetes";' >> sdk/nodejs/index.ts
 
 build_nodejs_sdk:: VERSION := $(shell pulumictl get version --language javascript)
 build_nodejs_sdk:: gen_nodejs_sdk

--- a/sdk/nodejs/index.ts
+++ b/sdk/nodejs/index.ts
@@ -40,5 +40,3 @@ pulumi.runtime.registerResourcePackage("cloud-toolkit-aws", {
         return new Provider(name, <any>undefined, { urn });
     },
 });
-import "@pulumi/aws";
-import "@pulumi/kubernetes";


### PR DESCRIPTION
**What type of PR is this?**

/kind deprecations

**What this PR does / why we need it**

The NodeJS SDK workaround to fix imports is not required anymore.

**Which issue(s) this PR fixes**

**Special notes for your reviewer**

**Does this PR introduce a user-facing change?**
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
