### PR TITLE
Added prefix to bucket name and minor fixes

### DIFF
--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/storage/__tests__/bucket.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/storage/__tests__/bucket.ts
@@ -88,6 +88,13 @@ describe("Full configuration", function () {
     component = await import("../index");
   });
 
+  test("It should configure bucket name", async function () {
+    const componentName = "test";
+    const instance = new component.Bucket(componentName, fullConfiguration, {});
+
+    expect(await GetValue(instance.bucket.bucket)).toBe(fullConfiguration.bucketName);
+  });
+
   test("It should encrypt our bucket", async function () {
     const componentName = "test";
     const instance = new component.Bucket(componentName, fullConfiguration, {});

--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/storage/__tests__/fixtures/full-configuration.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/storage/__tests__/fixtures/full-configuration.ts
@@ -2,6 +2,7 @@ import { BucketVersioningStateArgs } from "../../bucketArgs";
 
 export default {
   public: true,
+  bucketName: "s3-test",
   versioning: BucketVersioningStateArgs.Enabled,
   encryption: {
     enabled: true,

--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/storage/bucket.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/storage/bucket.ts
@@ -309,7 +309,6 @@ export class Bucket extends pulumi.ComponentResource {
     return new aws.s3.BucketV2(
       this.name,
       {
-        bucket: this.name,
         forceDestroy: true,
       },
       opts
@@ -386,7 +385,7 @@ export class Bucket extends pulumi.ComponentResource {
     }
 
     return new aws.s3.BucketPolicy(
-      this.name,
+      `${this.name}-bucketPolicy`,
       {
         bucket: this.bucket.id,
         policy: pulumi.interpolate`{

--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/storage/bucket.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/storage/bucket.ts
@@ -309,7 +309,9 @@ export class Bucket extends pulumi.ComponentResource {
     return new aws.s3.BucketV2(
       this.name,
       {
-        forceDestroy: true,
+        bucket: this.config.bucketName,
+        bucketPrefix: this.config.bucketNamePrefix,
+        forceDestroy: true
       },
       opts
     );

--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/storage/bucketArgs.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/storage/bucketArgs.ts
@@ -8,7 +8,7 @@ export interface BucketArgs {
   /**
    * Set to true to allow policies that may provide access to anyone.
   */
-  public: boolean;
+  public?: boolean;
 
   /**
    * Set a certain versioning mode for bucket objects
@@ -72,6 +72,7 @@ export enum BucketVersioningStateArgs {
 }
 
 export const defaultConfig = {
+  public: false,
   versioning: BucketVersioningStateArgs.Disabled,
   encryption: {
     enabled: false,
@@ -80,10 +81,6 @@ export const defaultConfig = {
 
 export function validateConfig(c: BucketArgs): BucketArgs {
   const config = defaultsDeep({ ...c }, defaultConfig);
-
-  if (config.public === undefined) {
-    throw Error("You must select if your bucket is public or not");
-  }
 
   if (
     config.website !== undefined &&

--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/storage/bucketArgs.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/storage/bucketArgs.ts
@@ -5,6 +5,17 @@ import defaultsDeep from "lodash.defaultsdeep";
  * Arguments to create a Cloud Toolkit Bucket component.
  */
 export interface BucketArgs {
+
+  /**
+   * Configures bucket name in AWS.
+  */
+  bucketName?: pulumi.Input<string>;
+
+  /**
+   * Configures a random bucket name in AWS but specifying a prefix name.
+  */
+  bucketNamePrefix?: pulumi.Input<string>;
+
   /**
    * Set to true to allow policies that may provide access to anyone.
   */

--- a/schema.yaml
+++ b/schema.yaml
@@ -1434,6 +1434,12 @@ types:
       - domainRecord
   cloud-toolkit-aws:storage:BucketArgs:
     properties:
+      bucketName:
+        description: Configures bucket name in AWS.
+        type: string
+      bucketNamePrefix:
+        description: Configures a random bucket name in AWS but specifying a prefix name.
+        type: string
       public:
         description: Set to true to allow policies that may provide access to anyone.
         type: boolean
@@ -3150,6 +3156,12 @@ resources:
       - readOnlyBucketPolicy
       - writeBucketPolicy
     inputProperties:
+      bucketName:
+        description: Configures bucket name in AWS.
+        type: string
+      bucketNamePrefix:
+        description: Configures a random bucket name in AWS but specifying a prefix name.
+        type: string
       public:
         description: Set to true to allow policies that may provide access to anyone.
         type: boolean

--- a/schema.yaml
+++ b/schema.yaml
@@ -1450,8 +1450,7 @@ types:
         description: Configures a static webpage using bucket files
         $ref: "#/types/cloud-toolkit-aws:storage:BucketWebsiteArgs"
     type: object
-    required:
-      - public
+    required: []
   cloud-toolkit-aws:storage:BucketEncryptionArgs:
     properties:
       enabled:
@@ -3166,8 +3165,7 @@ resources:
       website:
         description: Configures a static webpage using bucket files
         $ref: "#/types/cloud-toolkit-aws:storage:BucketWebsiteArgs"
-    requiredInputs:
-      - public
+    requiredInputs: []
     isComponent: true
     type: object
 language:

--- a/sdk/nodejs/storage/bucket.ts
+++ b/sdk/nodejs/storage/bucket.ts
@@ -87,6 +87,8 @@ export class Bucket extends pulumi.ComponentResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
+            resourceInputs["bucketName"] = args ? args.bucketName : undefined;
+            resourceInputs["bucketNamePrefix"] = args ? args.bucketNamePrefix : undefined;
             resourceInputs["encryption"] = args ? args.encryption : undefined;
             resourceInputs["public"] = args ? args.public : undefined;
             resourceInputs["replication"] = args ? args.replication : undefined;
@@ -126,6 +128,14 @@ export class Bucket extends pulumi.ComponentResource {
  * The set of arguments for constructing a Bucket resource.
  */
 export interface BucketArgs {
+    /**
+     * Configures bucket name in AWS.
+     */
+    bucketName?: pulumi.Input<string>;
+    /**
+     * Configures a random bucket name in AWS but specifying a prefix name.
+     */
+    bucketNamePrefix?: pulumi.Input<string>;
     /**
      * Configures encryption parameters for the bucket
      */

--- a/sdk/nodejs/storage/bucket.ts
+++ b/sdk/nodejs/storage/bucket.ts
@@ -83,13 +83,10 @@ export class Bucket extends pulumi.ComponentResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args: BucketArgs, opts?: pulumi.ComponentResourceOptions) {
+    constructor(name: string, args?: BucketArgs, opts?: pulumi.ComponentResourceOptions) {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
-            if ((!args || args.public === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'public'");
-            }
             resourceInputs["encryption"] = args ? args.encryption : undefined;
             resourceInputs["public"] = args ? args.public : undefined;
             resourceInputs["replication"] = args ? args.replication : undefined;
@@ -136,7 +133,7 @@ export interface BucketArgs {
     /**
      * Set to true to allow policies that may provide access to anyone.
      */
-    public: pulumi.Input<boolean>;
+    public?: pulumi.Input<boolean>;
     /**
      * Configures replication parameters for the bucket
      */

--- a/sdk/python/cloud_toolkit_aws/storage/bucket.py
+++ b/sdk/python/cloud_toolkit_aws/storage/bucket.py
@@ -17,6 +17,8 @@ __all__ = ['BucketArgs', 'Bucket']
 @pulumi.input_type
 class BucketArgs:
     def __init__(__self__, *,
+                 bucket_name: Optional[pulumi.Input[str]] = None,
+                 bucket_name_prefix: Optional[pulumi.Input[str]] = None,
                  encryption: Optional[pulumi.Input['BucketEncryptionArgsArgs']] = None,
                  public: Optional[pulumi.Input[bool]] = None,
                  replication: Optional[pulumi.Input['BucketReplicationArgsArgs']] = None,
@@ -24,12 +26,18 @@ class BucketArgs:
                  website: Optional[pulumi.Input['BucketWebsiteArgsArgs']] = None):
         """
         The set of arguments for constructing a Bucket resource.
+        :param pulumi.Input[str] bucket_name: Configures bucket name in AWS.
+        :param pulumi.Input[str] bucket_name_prefix: Configures a random bucket name in AWS but specifying a prefix name.
         :param pulumi.Input['BucketEncryptionArgsArgs'] encryption: Configures encryption parameters for the bucket
         :param pulumi.Input[bool] public: Set to true to allow policies that may provide access to anyone.
         :param pulumi.Input['BucketReplicationArgsArgs'] replication: Configures replication parameters for the bucket
         :param pulumi.Input['BucketVersioningStateArgs'] versioning: Set a certain versioning mode for bucket objects
         :param pulumi.Input['BucketWebsiteArgsArgs'] website: Configures a static webpage using bucket files
         """
+        if bucket_name is not None:
+            pulumi.set(__self__, "bucket_name", bucket_name)
+        if bucket_name_prefix is not None:
+            pulumi.set(__self__, "bucket_name_prefix", bucket_name_prefix)
         if encryption is not None:
             pulumi.set(__self__, "encryption", encryption)
         if public is not None:
@@ -40,6 +48,30 @@ class BucketArgs:
             pulumi.set(__self__, "versioning", versioning)
         if website is not None:
             pulumi.set(__self__, "website", website)
+
+    @property
+    @pulumi.getter(name="bucketName")
+    def bucket_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Configures bucket name in AWS.
+        """
+        return pulumi.get(self, "bucket_name")
+
+    @bucket_name.setter
+    def bucket_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "bucket_name", value)
+
+    @property
+    @pulumi.getter(name="bucketNamePrefix")
+    def bucket_name_prefix(self) -> Optional[pulumi.Input[str]]:
+        """
+        Configures a random bucket name in AWS but specifying a prefix name.
+        """
+        return pulumi.get(self, "bucket_name_prefix")
+
+    @bucket_name_prefix.setter
+    def bucket_name_prefix(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "bucket_name_prefix", value)
 
     @property
     @pulumi.getter
@@ -107,6 +139,8 @@ class Bucket(pulumi.ComponentResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 bucket_name: Optional[pulumi.Input[str]] = None,
+                 bucket_name_prefix: Optional[pulumi.Input[str]] = None,
                  encryption: Optional[pulumi.Input[pulumi.InputType['BucketEncryptionArgsArgs']]] = None,
                  public: Optional[pulumi.Input[bool]] = None,
                  replication: Optional[pulumi.Input[pulumi.InputType['BucketReplicationArgsArgs']]] = None,
@@ -118,6 +152,8 @@ class Bucket(pulumi.ComponentResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
+        :param pulumi.Input[str] bucket_name: Configures bucket name in AWS.
+        :param pulumi.Input[str] bucket_name_prefix: Configures a random bucket name in AWS but specifying a prefix name.
         :param pulumi.Input[pulumi.InputType['BucketEncryptionArgsArgs']] encryption: Configures encryption parameters for the bucket
         :param pulumi.Input[bool] public: Set to true to allow policies that may provide access to anyone.
         :param pulumi.Input[pulumi.InputType['BucketReplicationArgsArgs']] replication: Configures replication parameters for the bucket
@@ -148,6 +184,8 @@ class Bucket(pulumi.ComponentResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 bucket_name: Optional[pulumi.Input[str]] = None,
+                 bucket_name_prefix: Optional[pulumi.Input[str]] = None,
                  encryption: Optional[pulumi.Input[pulumi.InputType['BucketEncryptionArgsArgs']]] = None,
                  public: Optional[pulumi.Input[bool]] = None,
                  replication: Optional[pulumi.Input[pulumi.InputType['BucketReplicationArgsArgs']]] = None,
@@ -164,6 +202,8 @@ class Bucket(pulumi.ComponentResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = BucketArgs.__new__(BucketArgs)
 
+            __props__.__dict__["bucket_name"] = bucket_name
+            __props__.__dict__["bucket_name_prefix"] = bucket_name_prefix
             __props__.__dict__["encryption"] = encryption
             __props__.__dict__["public"] = public
             __props__.__dict__["replication"] = replication

--- a/sdk/python/cloud_toolkit_aws/storage/bucket.py
+++ b/sdk/python/cloud_toolkit_aws/storage/bucket.py
@@ -17,40 +17,29 @@ __all__ = ['BucketArgs', 'Bucket']
 @pulumi.input_type
 class BucketArgs:
     def __init__(__self__, *,
-                 public: pulumi.Input[bool],
                  encryption: Optional[pulumi.Input['BucketEncryptionArgsArgs']] = None,
+                 public: Optional[pulumi.Input[bool]] = None,
                  replication: Optional[pulumi.Input['BucketReplicationArgsArgs']] = None,
                  versioning: Optional[pulumi.Input['BucketVersioningStateArgs']] = None,
                  website: Optional[pulumi.Input['BucketWebsiteArgsArgs']] = None):
         """
         The set of arguments for constructing a Bucket resource.
-        :param pulumi.Input[bool] public: Set to true to allow policies that may provide access to anyone.
         :param pulumi.Input['BucketEncryptionArgsArgs'] encryption: Configures encryption parameters for the bucket
+        :param pulumi.Input[bool] public: Set to true to allow policies that may provide access to anyone.
         :param pulumi.Input['BucketReplicationArgsArgs'] replication: Configures replication parameters for the bucket
         :param pulumi.Input['BucketVersioningStateArgs'] versioning: Set a certain versioning mode for bucket objects
         :param pulumi.Input['BucketWebsiteArgsArgs'] website: Configures a static webpage using bucket files
         """
-        pulumi.set(__self__, "public", public)
         if encryption is not None:
             pulumi.set(__self__, "encryption", encryption)
+        if public is not None:
+            pulumi.set(__self__, "public", public)
         if replication is not None:
             pulumi.set(__self__, "replication", replication)
         if versioning is not None:
             pulumi.set(__self__, "versioning", versioning)
         if website is not None:
             pulumi.set(__self__, "website", website)
-
-    @property
-    @pulumi.getter
-    def public(self) -> pulumi.Input[bool]:
-        """
-        Set to true to allow policies that may provide access to anyone.
-        """
-        return pulumi.get(self, "public")
-
-    @public.setter
-    def public(self, value: pulumi.Input[bool]):
-        pulumi.set(self, "public", value)
 
     @property
     @pulumi.getter
@@ -63,6 +52,18 @@ class BucketArgs:
     @encryption.setter
     def encryption(self, value: Optional[pulumi.Input['BucketEncryptionArgsArgs']]):
         pulumi.set(self, "encryption", value)
+
+    @property
+    @pulumi.getter
+    def public(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Set to true to allow policies that may provide access to anyone.
+        """
+        return pulumi.get(self, "public")
+
+    @public.setter
+    def public(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "public", value)
 
     @property
     @pulumi.getter
@@ -127,7 +128,7 @@ class Bucket(pulumi.ComponentResource):
     @overload
     def __init__(__self__,
                  resource_name: str,
-                 args: BucketArgs,
+                 args: Optional[BucketArgs] = None,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Cloud Toolkit component for Bcukets. Creates a Simple Bucket for object storage
@@ -164,8 +165,6 @@ class Bucket(pulumi.ComponentResource):
             __props__ = BucketArgs.__new__(BucketArgs)
 
             __props__.__dict__["encryption"] = encryption
-            if public is None and not opts.urn:
-                raise TypeError("Missing required property 'public'")
             __props__.__dict__["public"] = public
             __props__.__dict__["replication"] = replication
             __props__.__dict__["versioning"] = versioning


### PR DESCRIPTION
**What type of PR is this?**
/kind improvement


**What this PR does / why we need it**

1) Include prefix to bucket name to avoid conflict naming in AWS
2) Make visibility attribute as opcional and being a bucket private by default

**Which issue(s) this PR fixes**
Fixes #107 

**Special notes for your reviewer**
After an analysis for bucket prefix issue, I have descarted to use [bucketPrefix](https://www.pulumi.com/registry/packages/aws/api-docs/s3/bucketv2/#bucketprefix_nodejs) because it make bucket name too long.

Just by deleting bucket variable in Bucket declaration, Pulumi does the job of ensuring no conflicts and providing concise names.

**Does this PR introduce a user-facing change?**
```changelog
Set public property as optional in Bucket component
```