### PR TITLE
Added OwnershipControl for logs bucket for Static Web component

### DIFF
--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/serverless/staticweb.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/serverless/staticweb.ts
@@ -139,7 +139,7 @@ export class StaticWeb extends pulumi.ComponentResource {
     if (validatedArgs.configureDNS) {
       this.DNSRecords = this.createDNSRecords(validatedArgs);
     }
-
+    
     this.registerOutputs({
       contentBucket: this.contentBucket,
       logsBucket: this.logsBucket,
@@ -177,13 +177,26 @@ export class StaticWeb extends pulumi.ComponentResource {
   }
 
   createLogsBucket({ domain }: StaticWebArgs): aws.s3.Bucket {
-    return new aws.s3.Bucket(
+    const bucket = new aws.s3.Bucket(
       `${this.name}-request-logs`,
-      {
-        acl: "private",
-      },
+      {}, 
       { parent: this }
     );
+    
+    const bucketOwnershipControls = new aws.s3.BucketOwnershipControls(
+      `${this.name}-request-logs-ownership-control`,
+      {
+        bucket: bucket.id,
+        rule: {
+          objectOwnership: "BucketOwnerPreferred"
+        }
+      },
+      {
+        parent: bucket
+      }
+    )
+
+    return bucket
   }
 
   createCloudFrontOriginAccessIdentity(): aws.cloudfront.OriginAccessIdentity {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**
Due to a change in the AWS API regarding buckets permissions done in April 2023, the Request Logs bucket for the Static Web component did not support ACLs. This PR solves this issue by adding a `BucketOwnershipControls` to the logs bucket.

**Which issue(s) this PR fixes**

**Special notes for your reviewer**

**Does this PR introduce a user-facing change?**
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Fixed StaticWeb logs bucket creation by adding a BucketOwnershipControl to it.
```
