### PR TITLE
Fix volume provisioning with EBS

### DIFF
--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/kubernetes/clusterAddons.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/kubernetes/clusterAddons.ts
@@ -334,7 +334,7 @@ export class ClusterAddons extends pulumi.ComponentResource {
       {
         name: "aws-ebs-csi-driver",
         namespace: "kube-system",
-        serviceAccountName: "ebs-csi-driver",
+        serviceAccountName: "ebs-csi-controller-sa",
         k8sProvider: this.args.k8sProvider,
         createNamespace: false,
         identityProvidersArn: this.args.identityProvidersArn,

--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/kubernetes/ebsCsiDriver.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/kubernetes/ebsCsiDriver.ts
@@ -215,12 +215,32 @@ export class AwsEbsCsiDriver extends ApplicationAddon<AwsEbsCsiDriverArgs> {
           releaseName: this.args.name,
           parameters: [
             {
-              name: "serviceAccount.create",
+              name: "controller.serviceAccount.create",
               value: "false",
             },
             {
-              name: "serviceAccount.name",
-              value: this.irsa.name,
+              name: "controller.replicaCount",
+              value: "1",
+            },
+            {
+              name: "controller.serviceAccount.name",
+              value: this.irsa.serviceAccount.metadata.name,
+            },
+            {
+              name: "storageClasses[0].name",
+              value: "ebs-sc"
+            },
+            {
+              name: "storageClasses[0].labels[0].name",
+              value: "ebs-sc"
+            },
+            {
+              name: "storageClasses[0].volumeBindingMode",
+              value: "WaitForFirstConsumer"
+            },
+            {
+              name: "storageClasses[0].reclaimPolicy",
+              value: "Delete"
             },
           ],
         },


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**
Upgrading the Kubernetes cluster to 1.23 introduced a bug that broke Persistent Volumes and Persistent Volumes Claims.

The issue was that the EBS CSI driver was being incorrectly installed, and previous versions of the cluster defaulted to the already existing kubernetes.io driver. It was deprecated for 1.23, so old and new volumes started to fail.

This PR fixes the EBS CSI driver installation and also install a Storage Class that is ready to use.

**Special notes for your reviewer**

**Does this PR introduce a user-facing change?**
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Fixed Volume creation for 1.23 Kubernetes Clusters
```
