### PR TITLE
Adding EKS missing policy required to deploy new clusters

### DIFF
--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/kubernetes/cluster.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/kubernetes/cluster.ts
@@ -52,9 +52,14 @@ export class Cluster extends pulumi.ComponentResource {
   public readonly role: aws.iam.Role;
 
   /**
-   * The IAM Role Policy Attachment to assign the IAM Policies to the IAM Role.
+   * The IAM Role Policy Attachment to assign the AWS managed policy AmazonEKSClusterPolicy to the IAM Role.
    */
   public readonly rolePolicyAttachment: aws.iam.RolePolicyAttachment;
+
+  /**
+   * The IAM Role Policy Attachment to assign the AWS managed policy AmazonEKSServicePolicy to the IAM Role.
+   */
+  public readonly rolePolicyAttachmentService: aws.iam.RolePolicyAttachment;
 
   /**
    * The Security Group associated to the EKS Cluster.
@@ -141,6 +146,7 @@ export class Cluster extends pulumi.ComponentResource {
     this.subnetTags = this.setupSubnetTags(resourceOpts);
     this.role = this.setupRole(resourceOpts);
     this.rolePolicyAttachment = this.setupRolePolicyAttachment(resourceOpts);
+    this.rolePolicyAttachmentService = this.setupRolePolicyAttachmentService(resourceOpts);
     this.securityGroup = this.setupClusterSecurityGroup(resourceOpts);
 
     const clusterOpts = pulumi.mergeOptions(resourceOpts, {
@@ -316,6 +322,19 @@ export class Cluster extends pulumi.ComponentResource {
       this.name,
       {
         policyArn: "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy",
+        role: this.role.name,
+      },
+      opts
+    );
+  }
+
+  private setupRolePolicyAttachmentService(
+    opts: pulumi.ResourceOptions
+  ): aws.iam.RolePolicyAttachment {
+    return new aws.iam.RolePolicyAttachment(
+      `${this.name}-service`,
+      {
+        policyArn: "arn:aws:iam::aws:policy/AmazonEKSServicePolicy",
         role: this.role.name,
       },
       opts

--- a/provider/cmd/pulumi-resource-cloud-toolkit-aws/provider.ts
+++ b/provider/cmd/pulumi-resource-cloud-toolkit-aws/provider.ts
@@ -187,6 +187,7 @@ async function constructKubernetesCluster(
       provisionerProvider: resource.provisionerProvider,
       role: resource.role,
       rolePolicyAttachment: resource.rolePolicyAttachment,
+      rolePolicyAttachmentService: resource.rolePolicyAttachmentService,
       securityGroup: resource.securityGroup,
       subnetTags: resource.subnetTags,
     },

--- a/schema.yaml
+++ b/schema.yaml
@@ -2263,8 +2263,12 @@ resources:
         description: The IAM Role assumed by the EKS Cluster.
         $ref: /aws/v5.10.0/schema.json#/resources/aws:iam%2frole:Role
       rolePolicyAttachment:
-        description: The IAM Role Policy Attachment to assign the IAM Policies to the
-          IAM Role.
+        description: The IAM Role Policy Attachment to assign the AWS managed policy 
+          AmazonEKSClusterPolicy to the IAM Role.
+        $ref: /aws/v5.10.0/schema.json#/resources/aws:iam%2frolePolicyAttachment:RolePolicyAttachment
+      rolePolicyAttachmentService:
+        description: The IAM Role Policy Attachment to assign the AWS managed policy 
+          AmazonEKSServicePolicy to the IAM Role.
         $ref: /aws/v5.10.0/schema.json#/resources/aws:iam%2frolePolicyAttachment:RolePolicyAttachment
       securityGroup:
         description: The Security Group associated to the EKS Cluster.
@@ -2304,6 +2308,7 @@ resources:
       - provisionerProvider
       - role
       - rolePolicyAttachment
+      - rolePolicyAttachmentService
       - securityGroup
       - cluster
       - kubeconfig

--- a/sdk/nodejs/kubernetes/cluster.ts
+++ b/sdk/nodejs/kubernetes/cluster.ts
@@ -79,9 +79,13 @@ export class Cluster extends pulumi.ComponentResource {
      */
     public /*out*/ readonly role!: pulumi.Output<pulumiAws.iam.Role>;
     /**
-     * The IAM Role Policy Attachment to assign the IAM Policies to the IAM Role.
+     * The IAM Role Policy Attachment to assign the AWS managed policy AmazonEKSClusterPolicy to the IAM Role.
      */
     public /*out*/ readonly rolePolicyAttachment!: pulumi.Output<pulumiAws.iam.RolePolicyAttachment>;
+    /**
+     * The IAM Role Policy Attachment to assign the AWS managed policy AmazonEKSServicePolicy to the IAM Role.
+     */
+    public /*out*/ readonly rolePolicyAttachmentService!: pulumi.Output<pulumiAws.iam.RolePolicyAttachment>;
     /**
      * The Security Group associated to the EKS Cluster.
      */
@@ -126,6 +130,7 @@ export class Cluster extends pulumi.ComponentResource {
             resourceInputs["provisionerRolePolicy"] = undefined /*out*/;
             resourceInputs["role"] = undefined /*out*/;
             resourceInputs["rolePolicyAttachment"] = undefined /*out*/;
+            resourceInputs["rolePolicyAttachmentService"] = undefined /*out*/;
             resourceInputs["securityGroup"] = undefined /*out*/;
             resourceInputs["subnetTags"] = undefined /*out*/;
         } else {
@@ -142,6 +147,7 @@ export class Cluster extends pulumi.ComponentResource {
             resourceInputs["provisionerRolePolicy"] = undefined /*out*/;
             resourceInputs["role"] = undefined /*out*/;
             resourceInputs["rolePolicyAttachment"] = undefined /*out*/;
+            resourceInputs["rolePolicyAttachmentService"] = undefined /*out*/;
             resourceInputs["securityGroup"] = undefined /*out*/;
             resourceInputs["subnetTags"] = undefined /*out*/;
         }

--- a/sdk/python/cloud_toolkit_aws/kubernetes/cluster.py
+++ b/sdk/python/cloud_toolkit_aws/kubernetes/cluster.py
@@ -325,6 +325,7 @@ class Cluster(pulumi.ComponentResource):
             __props__.__dict__["provisioner_role_policy"] = None
             __props__.__dict__["role"] = None
             __props__.__dict__["role_policy_attachment"] = None
+            __props__.__dict__["role_policy_attachment_service"] = None
             __props__.__dict__["security_group"] = None
             __props__.__dict__["subnet_tags"] = None
         super(Cluster, __self__).__init__(
@@ -434,9 +435,17 @@ class Cluster(pulumi.ComponentResource):
     @pulumi.getter(name="rolePolicyAttachment")
     def role_policy_attachment(self) -> pulumi.Output['pulumi_aws.iam.RolePolicyAttachment']:
         """
-        The IAM Role Policy Attachment to assign the IAM Policies to the IAM Role.
+        The IAM Role Policy Attachment to assign the AWS managed policy AmazonEKSClusterPolicy to the IAM Role.
         """
         return pulumi.get(self, "role_policy_attachment")
+
+    @property
+    @pulumi.getter(name="rolePolicyAttachmentService")
+    def role_policy_attachment_service(self) -> pulumi.Output['pulumi_aws.iam.RolePolicyAttachment']:
+        """
+        The IAM Role Policy Attachment to assign the AWS managed policy AmazonEKSServicePolicy to the IAM Role.
+        """
+        return pulumi.get(self, "role_policy_attachment_service")
 
     @property
     @pulumi.getter(name="securityGroup")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**
Attaches a policy to the AWS IAM role that deploys a kubernetes cluster. This is required for new deployments, existing ones are not affected.

**Which issue(s) this PR fixes**

**Special notes for your reviewer**

**Does this PR introduce a user-facing change?**
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Added EKS missing policy required to deploy new clusters
```
